### PR TITLE
Self Benchmark yourself Mr. Strawberryfield

### DIFF
--- a/config/install/strawberryfield.general.yml
+++ b/config/install/strawberryfield.general.yml
@@ -1,0 +1,1 @@
+benchmark: TRUE

--- a/config/schema/strawberryfield.schema.yml
+++ b/config/schema/strawberryfield.schema.yml
@@ -148,3 +148,11 @@ strawberryfield.filepersister_service_settings:
     fido_exec_path:
       type: string
       label: 'FIDO binary full executable path'
+
+strawberryfield.general:
+  type: config_object
+  label: General SBF Module settings
+  mapping:
+    benchmark:
+      type: boolean
+      label: Benchmark time and memory usage of Event Subscribers

--- a/src/EventSubscriber/StrawberryfieldEventPresaveSubscriberAsFileStructureGenerator.php
+++ b/src/EventSubscriber/StrawberryfieldEventPresaveSubscriberAsFileStructureGenerator.php
@@ -189,8 +189,8 @@ class StrawberryfieldEventPresaveSubscriberAsFileStructureGenerator extends Stra
       $this->messenger->addStatus(
         $this->stringTranslation->formatPlural(
           $newlyprocessed,
-          'Very good. New file metadata structured created.',
-          'Great! @count new files metadata structured created.'
+          'Very good. New file metadata structure created.',
+          'Great! @count new files metadata structures created.'
         )
       );
     }

--- a/src/StrawberryfieldFilePersisterService.php
+++ b/src/StrawberryfieldFilePersisterService.php
@@ -528,7 +528,6 @@ class StrawberryfieldFilePersisterService {
         $found['urn:uuid:' . $info['dr:uuid']] = $info;
       }
     }
-    dpm(count($found));
     return $found;
   }
 

--- a/src/StrawberryfieldUtilityService.php
+++ b/src/StrawberryfieldUtilityService.php
@@ -200,4 +200,23 @@ class StrawberryfieldUtilityService {
     }
     return $canexecute;
   }
+
+  /**
+   * Format a quantity of bytes.
+   *
+   * @param int $size
+   * @param int $precision
+   *
+   * @return string
+   */
+  public function formatBytes($size, $precision = 2)
+  {
+    if ($size === 0) {
+      return 0;
+    }
+    $base = log($size, 1024);
+    $suffixes = array('', 'k', 'M', 'G', 'T');
+    return round(pow(1024, $base - floor($base)), $precision) . $suffixes[floor($base)];
+  }
+
 }

--- a/strawberryfield.module
+++ b/strawberryfield.module
@@ -25,12 +25,38 @@ use Drupal\Core\Field\FieldItemListInterface;
  */
 function strawberryfield_node_presave(ContentEntityInterface $entity) {
 
+
   if ($sbf_fields = \Drupal::service('strawberryfield.utility')->bearsStrawberryfield($entity)) {
+    $config = \Drupal::config('strawberryfield.general');
+    $bench = FALSE;
+    // When benchmark is enabled a simple but effective report will be found in the reports/logs
+    if ($config->get('benchmark')) {
+      $bench = TRUE;
+    }
+    // Introducing our newest development, the processing time stats!
+    $start_time = microtime(true);
+
     $event_type = StrawberryfieldEventType::PRESAVE;
     $event = new StrawberryfieldCrudEvent($event_type, $entity, $sbf_fields);
     /** @var \Symfony\Component\EventDispatcher\EventDispatcher $dispatcher */
     $dispatcher = \Drupal::service('event_dispatcher');
     $dispatcher->dispatch($event_type, $event);
+
+    if ($bench) {
+      $end_time = microtime(TRUE);
+      $time = bcsub($end_time, $start_time, 4);
+      $max_memory = memory_get_peak_usage(TRUE);
+      \Drupal::logger('strawberryfield')->notice(
+        'ADO with UUID @uuid spend @time ms on all presave event subscriber processing and max memory usage was @maxmem. Event Subscribers that run where the following <br> @events',
+        [
+          '@uuid' => $entity->uuid(),
+          '@time' => $time,
+          '@maxmem' => \Drupal::service('strawberryfield.utility')->formatBytes($max_memory, 2),
+          '@events' => print_r($event->getProcessedBy(), TRUE),
+        ]
+      );
+    }
+
   }
 
 }


### PR DESCRIPTION
@giancarlobi first steps into self benchmarking and also what we can/will use in the future to measure how much/can/should archipelago do in real time v/s background. I started with some simple data. strawberryfield.general.yml Needs to be imported as a config file to get this running. Form exposure will follow. I want to keep track also of the other events dispatched so we can accumulate stats. For 3 larger files, on my super slow local dev docker environment, PHP used 2Mbytes Peak but only 3.46ms in all processing, including running exif, fido and persisting. Need to measure now how long it takes to do the same for DB insert.