### PR TITLE
Add second parameter to converter (#102)

### DIFF
--- a/strawberryfield.services.yml
+++ b/strawberryfield.services.yml
@@ -54,4 +54,6 @@ services:
     class: Drupal\strawberryfield\ParamConverter\UuidEntityConverter
     tags:
       - { name: paramconverter , priority: 10 }
-    arguments: ['@entity_type.manager']
+    arguments:
+      - '@entity_type.manager'
+      - '@entity.repository'


### PR DESCRIPTION
 Parameter Converter we built to upcast and UUID into a Node (do/uuid) requires two arguments in the constructor. This is a service so arguments are passed as injected dependencies.