### PR TITLE
Do not over process. Key value == $item_id passed by tracker

### DIFF
--- a/src/Plugin/search_api/datasource/StrawberryfieldFlavorDatasource.php
+++ b/src/Plugin/search_api/datasource/StrawberryfieldFlavorDatasource.php
@@ -634,11 +634,10 @@ class StrawberryfieldFlavorDatasource extends DatasourcePluginBase implements Pl
         $file = $files ? reset($files) : NULL;
 
         if ($file && $plugin_id !== NULL) {
-          $keyvaluekey = $keyvalue_collection . ':' . $fid_uuid . ':' . $plugin_id;
           $processed_data = $this->keyValue->get($keyvalue_collection)->get(
-            $keyvaluekey
+            $item_id
           );
-
+          // Put the package File ID / Package.
           $fulltext = isset($processed_data->fulltext) ? (string) $processed_data->fulltext : '';
           $checksum = isset($processed_data->checksum) ? (string) $processed_data->checksum : NULL;
           if ($checksum) {


### PR DESCRIPTION
@giancarlobi this addresses the issue with duplicated values. I was using an old ID to save temporary and recover during index in the keyvalue. Now both are equal. Easier