### PR TITLE
ISSUE-165: plaintext and total sequence count capabilities to SBF Fla…

### DIFF
--- a/config/schema/strawberryfield.schema.yml
+++ b/config/schema/strawberryfield.schema.yml
@@ -131,6 +131,10 @@ plugin.plugin_configuration.search_api_datasource.strawberryfield_flavor_datasou
           sequence:
             type: string
             label: 'A language code'
+    metadatadisplayentity_source:
+      type: string
+      label: "Metadata Display Entity to be used to Display the results"
+
 field.widget.settings.strawberry_textarea:
   type: config_object
   label: 'Strawberry Textarea Widget Schema'
@@ -185,7 +189,7 @@ field.formatter.settings.strawberry_default_formatter:
       type: string
       label: 'Access level the user needs on a bundle to be able to see it rendered, defaults to "edit"'
 
-# Multiple JSON type / View Mode Mappings
+# Hydroponics schema
 strawberryfield.hydroponics_settings:
   type: config_object
   label: 'Queues enabled to be processed by the Hydroponics Service'
@@ -205,3 +209,12 @@ strawberryfield.hydroponics_settings:
       sequence:
         type: string
         label: 'Queue Names'
+    processing_type:
+      type: string
+      label: 'Type of Processing to do, either mono or multi child'
+    processing_monotime:
+      type: integer
+      label: 'Time for the mono process to lease a queue item'
+    processing_multinumber:
+      type: integer
+      label: 'Number of Child processes for the multiqueue'

--- a/src/EventSubscriber/StrawberryEventDeleteFlavorSubscriber.php
+++ b/src/EventSubscriber/StrawberryEventDeleteFlavorSubscriber.php
@@ -3,19 +3,17 @@
 namespace Drupal\strawberryfield\EventSubscriber;
 
 use Drupal\Core\Entity\EntityInterface;
-use Drupal\Core\KeyValueStore\KeyValueFactoryInterface;
-use Drupal\file\FileInterface;
 use Drupal\search_api\Query\QueryInterface;
 use Drupal\search_api\Utility\Utility;
+use Drupal\Core\KeyValueStore\KeyValueFactoryInterface;
 use Drupal\strawberryfield\Event\StrawberryfieldCrudEvent;
 use Drupal\strawberryfield\Plugin\search_api\datasource\StrawberryfieldFlavorDatasource;
-use Drupal\strawberryfield\Tools\Ocfl\OcflHelper;
 use Drupal\search_api\SearchApiException;
 
 /**
  * Event subscriber for SBF bearing entity json process event.
  */
-class StrawberryEventSaveFileDeleteFlavorSubscriber extends StrawberryfieldEventSaveSubscriber {
+class StrawberryEventDeleteFlavorSubscriber extends StrawberryfieldEventDeleteSubscriber {
 
   /**
    * {@inheritdoc}
@@ -39,51 +37,36 @@ class StrawberryEventSaveFileDeleteFlavorSubscriber extends StrawberryfieldEvent
     $this->keyValue = $keyvalue;
   }
 
+
   /**
    * {@inheritdoc}
    */
-  public function onEntitySave(StrawberryfieldCrudEvent $event) {
+  public function onEntityDelete(StrawberryfieldCrudEvent $event) {
     // We need to compare the original entity with the saved just now as file
     // events don't really work for this use case. The file is still attached to
     // the revisions. This event is run only on update, so we're not treating
     // the isNew() possibility here.
-    $entity = $event->getEntity();
-    $original_entity = $entity->original;
-
-    // We only care about the original entity ones, so that's the system of
-    // record to compare. If $files_deleted is empty, it means new files, or no
-    // deletions so we don't treat those.
-    $entity_files = array_column($entity->get('field_file_drop')->getValue() ?? [], 'target_id');
-    $original_entity_files = array_column($original_entity->get('field_file_drop')->getValue() ?? [], 'target_id');
-    $files_deleted = array_diff($original_entity_files, $entity_files);
-
-    foreach ($files_deleted as $file_id) {
-      $file = OcflHelper::resolvetoFIDtoURI($file_id);
-      // No need to review if the file is being used somewhere else as we're
-      // removing the tracking contextually to the entity.
-      $this->trackFilesDeleted($entity, $file);
-    }
-    $current_class = get_called_class();
-    $event->setProcessedBy($current_class, TRUE);
+      $entity = $event->getEntity();
+      $this->trackDeleted($entity);
+      $current_class = get_called_class();
+      $event->setProcessedBy($current_class, TRUE);
   }
 
   /**
-   * Deletes the documents tracked on Search Api.
+   * Deletes all documents tracked on Search Api for an ADO.
    *
    * @param \Drupal\Core\Entity\EntityInterface $entity
-   *   The entity to delete flavors contextually.
-   * @param \Drupal\file\FileInterface $file
-   *   The file associated to the entity.
+   *   The entity to delete all flavors from.
    *
    * @throws \Drupal\search_api\SearchApiException
    */
-  protected function trackFilesDeleted(EntityInterface $entity, FileInterface $file) {
+  protected function trackDeleted(EntityInterface $entity) {
+
     $datasource_id = 'strawberryfield_flavor_datasource';
     $limit = 200;
     foreach (StrawberryfieldFlavorDatasource::getValidIndexes() as $index) {
       $query = $index->query(['offset' => 0, 'limit' => $limit]);
-      $query->addCondition('file_uuid', $file->uuid())
-        ->addCondition('search_api_datasource', $datasource_id)
+      $query->addCondition('search_api_datasource', $datasource_id)
         ->addCondition('uuid', $entity->uuid());
       $query->setOption('search_api_retrieved_field_values', ['id']);
       // Query breaks if not because standard hl is enabled for all fields.
@@ -118,6 +101,7 @@ class StrawberryEventSaveFileDeleteFlavorSubscriber extends StrawberryfieldEvent
         // Untrack after all possible query calls with offsets.
         if (count($tracked_ids) > 0) {
           $index->trackItemsDeleted($datasource_id, $tracked_ids);
+          // Removes temporary stored Flavors from Key Collection
           $this->keyValue
             ->get(StrawberryfieldFlavorDatasource::SBFL_KEY_COLLECTION)
             ->deleteMultiple($tracked_ids);
@@ -128,5 +112,4 @@ class StrawberryEventSaveFileDeleteFlavorSubscriber extends StrawberryfieldEvent
       }
     }
   }
-
 }

--- a/src/EventSubscriber/StrawberryfieldEventSearchApiForeignRelationshipsMapping.php
+++ b/src/EventSubscriber/StrawberryfieldEventSearchApiForeignRelationshipsMapping.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Drupal\strawberryfield\EventSubscriber;
+
+use Drupal\search_api\Event\SearchApiEvents;
+use Drupal\search_api\Event\MappingForeignRelationshipsEvent;
+use Drupal\strawberryfield\StrawberryfieldUtilityService;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Event subscriber to alter Foreign Relationships for Indexed Strawberryfields.
+ */
+class StrawberryfieldEventSearchApiForeignRelationshipsMapping implements EventSubscriberInterface {
+
+  /**
+   * @var int
+   */
+  protected static $priority = -700;
+
+  /**
+   * The Strawberry Field Utility Service.
+   *
+   * @var \Drupal\strawberryfield\StrawberryfieldUtilityService
+   */
+  protected $strawberryfieldUtility;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+
+    $events[SearchApiEvents::MAPPING_FOREIGN_RELATIONSHIPS][] = ['alterMapping', static::$priority];
+    return $events;
+  }
+
+  public function __construct(StrawberryfieldUtilityService $strawberryfield_utility_service) {
+   $this->strawberryfieldUtility = $strawberryfield_utility_service;
+  }
+
+  /**
+   * Method called when Event occurs.
+   *
+   * @param \Drupal\search_api\Event\MappingForeignRelationshipsEvent $event
+   *   The event.
+   */
+  public function alterMapping(MappingForeignRelationshipsEvent $event) {
+    $sbf_machine_names = $this->strawberryfieldUtility->getStrawberryfieldMachineNames();
+    if (is_array($sbf_machine_names) && count($sbf_machine_names)) {
+      foreach ($event->getForeignRelationshipsMapping() as $key => $mapping) {
+        if ($mapping['datasource'] == 'entity:node') {
+          $property_path = explode(":", $mapping['property_path_to_foreign_entity']);
+          if (in_array($property_path[0], $sbf_machine_names)) {
+            // We can not trigger \Drupal::getContainer()->get('search_api.tracking_helper')
+            //    ->trackReferencedEntityUpdate($entity);
+            // Because at this level we have no idea which entity was modified
+            unset($event->getForeignRelationshipsMapping()[$key]);
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/Plugin/search_api/datasource/StrawberryfieldFlavorDatasource.php
+++ b/src/Plugin/search_api/datasource/StrawberryfieldFlavorDatasource.php
@@ -6,12 +6,14 @@ use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityDisplayRepositoryInterface;
 use Drupal\Core\TypedData\ComplexDataInterface;
 use Drupal\search_api\Datasource\DatasourcePluginBase;
+use Drupal\search_api\LoggerTrait;
 use Drupal\strawberryfield\TypedData\StrawberryfieldFlavorDataDefinition;
 use Drupal\Core\Language\LanguageInterface;
 use Drupal\search_api\Utility\Utility;
 use Drupal\search_api\Plugin\PluginFormTrait;
 use Drupal\Core\Form\FormStateInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\Core\Plugin\PluginDependencyTrait;
 
 /**
  * Represents a datasource which exposes flavors.
@@ -24,6 +26,14 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class StrawberryfieldFlavorDatasource extends DatasourcePluginBase implements StrawberryfieldFlavorDatasourceInterface {
 
   use PluginFormTrait;
+  use PluginDependencyTrait;
+  use LoggerTrait;
+
+  /**
+   * The Key Value Collection used to store temp values for Items
+   */
+  public const SBFL_KEY_COLLECTION = 'Strawberryfield_flavor_datasource_temp';
+
 
   /**
    * The entity type manager.
@@ -141,6 +151,10 @@ class StrawberryfieldFlavorDatasource extends DatasourcePluginBase implements St
   /**
    * {@inheritdoc}
    */
+  public function canContainEntityReferences(): bool {
+    return TRUE;
+  }
+
   public function getItemId(ComplexDataInterface $item) {
     // @TODO This id is not the one for a particular flavor
     // but the one from the source, which in this case is a node
@@ -183,6 +197,47 @@ class StrawberryfieldFlavorDatasource extends DatasourcePluginBase implements St
    */
   public function getItemIds($page = NULL) {
     return $this->getPartialItemIds($page);
+  }
+
+  /**
+   * Retrieves a scalar field value from a result item.
+   *
+   * @param \Drupal\Core\TypedData\ComplexDataInterface $item
+   *   The result item.
+   * @param string $config_key
+   *   The key in the configuration.
+   *
+   * @return mixed|null
+   *   The scalar value of the specified field (first value for multi-valued
+   *   fields), if it exists; NULL otherwise.
+   *
+   * @throws \Drupal\Core\TypedData\Exception\MissingDataException
+   */
+  protected function getFieldValue(ComplexDataInterface $item, $config_key) {
+    if (empty($this->configuration[$config_key])) {
+      return NULL;
+    }
+    $values = $item->get($this->configuration[$config_key])->getValue();
+    if (is_array($values)) {
+      $values = $values ? reset($values) : NULL;
+    }
+    return $values ?: NULL;
+  }
+  /**
+   * {@inheritdoc}
+   *
+   * @throws \Drupal\Core\TypedData\Exception\MissingDataException
+   */
+  public function getItemLabel(ComplexDataInterface $item) {
+    if ($this->getFieldValue($item, 'label_field')) {
+      return $this->getFieldValue($item, 'label_field');
+    }
+    elseif ($entity = $this->getEntity($item)) {
+      return $entity->label();
+    }
+    else {
+      return NULL;
+    }
   }
 
   /**
@@ -353,6 +408,8 @@ class StrawberryfieldFlavorDatasource extends DatasourcePluginBase implements St
       ];
     }
 
+    $default_configuration['metadatadisplayentity_source'] = NULL;
+
     return $default_configuration;
   }
 
@@ -410,9 +467,38 @@ class StrawberryfieldFlavorDatasource extends DatasourcePluginBase implements St
         '#multiple' => TRUE,
       ];
     }
+    if ($this->moduleHandler()->moduleExists('format_strawberryfield')) {
 
+      $entity = NULL;
+      if ($this->configuration['metadatadisplayentity_source']) {
+        $entity = $this->entityTypeManager->getStorage(
+          'metadatadisplay_entity'
+        )->load($this->configuration['metadatadisplayentity_source']);
+      }
+      $form['metadatadisplayentity_source'] = [
+        '#title' => $this->t('A Metadata Display entity (Twig Template) to be used to Render a single Item.'),
+        '#type' => 'entity_autocomplete',
+        '#target_type' => 'metadatadisplay_entity',
+        '#selection_handler' => 'default:metadatadisplay',
+        '#validate_reference' => FALSE,
+        '#default_value' => $entity,
+        '#states' => [
+          'visible' => [
+            ':input[data-formatter-selector="mediasource"]' => ['value' => 'metadatadisplayentity'],
+          ],
+        ],
+      ];
+    }
+    else {
+      $form['metadatadisplayentity_source'] = [
+        '#type' => 'value',
+        '#default_value' => NULL,
+      ];
+    }
     return $form;
   }
+
+
 
   /**
    * {@inheritdoc}
@@ -436,12 +522,11 @@ class StrawberryfieldFlavorDatasource extends DatasourcePluginBase implements St
     // This is the structure of one of our ids
     // Means one $entity_ids_splitted will contain this splitted
     // $id = $entity->id() . ':'.$sequence .':'.$translation_id.':'.$file->uuid().':'.$data->plugin_config_entity_id;
-    $keyvalue_collection = 'Strawberryfield_flavor_datasource_temp';
+    $keyvalue_collection = self::SBFL_KEY_COLLECTION;
 
-    foreach ($this->getEntityStorage()->loadMultiple(
-      $entity_ids
-    ) as $entity_id => $entity) {
+    foreach ($this->getEntityStorage()->loadMultiple($entity_ids) as $entity_id => $entity) {
       foreach ($entity_ids_splitted[$entity_id] as $item_id => $splitted_id_for_node) {
+        $sequence_id = !empty($splitted_id_for_node[1]) ? $splitted_id_for_node[1] : 1;
         $fid_uuid = isset($splitted_id_for_node[3]) ? $splitted_id_for_node[3] : NULL;
         $plugin_id = isset($splitted_id_for_node[4]) ? $splitted_id_for_node[4] : NULL;
         // probably we will want to add the module/class namespace for the plugin id?
@@ -458,17 +543,21 @@ class StrawberryfieldFlavorDatasource extends DatasourcePluginBase implements St
           );
           // Put the package File ID / Package.
           $fulltext = isset($processed_data->fulltext) ? (string) $processed_data->fulltext : '';
+          $plaintext = isset($processed_data->plaintext) ? (string) $processed_data->plaintext : '';
           $checksum = isset($processed_data->checksum) ? (string) $processed_data->checksum : NULL;
+          $sequence_total = isset($processed_data->sequence_total) ? (string) $processed_data->sequence_total : $sequence_id;
           if ($checksum) {
             $data = [
               'item_id' => $item_id,
-              'sequence_id' => $splitted_id_for_node[1],
+              'sequence_id' => $sequence_id,
+              'sequence_total' => $sequence_total,
               'target_id' => $splitted_id_for_node[0],
               'parent_id' => $splitted_id_for_node[0],
               'file_uuid' => $fid_uuid,
               'target_fileid' => $file->id(),
               'processor_id' => $plugin_id,
               'fulltext' => '',
+              'plaintext' => '',
               'checksum' => $checksum,
             ];
             // This will then always create a new Index document, even if empty.
@@ -477,6 +566,16 @@ class StrawberryfieldFlavorDatasource extends DatasourcePluginBase implements St
             if (!empty(trim($fulltext))) {
               $data['fulltext'] = trim($fulltext);
             }
+            if (!empty(trim($plaintext))) {
+              $data['plaintext'] = trim($plaintext);
+            }
+            elseif (!empty($data['fulltext'])) {
+              // This assumes miniOCR and is only meant for backwards compat
+              // for existing Solr Documents/ Data Sources.
+              $data['plaintext'] = str_replace("<w>", "<w> ", $data['fulltext']);
+              $data['plaintext'] = strip_tags(str_replace("<l>", PHP_EOL . "<l> ", $data['plaintext']));
+            }
+
             $documents[$item_id] = $this->typedDataManager->create(
               $sbfflavordata_definition
             );
@@ -484,14 +583,16 @@ class StrawberryfieldFlavorDatasource extends DatasourcePluginBase implements St
           }
         }
         else {
-          //@TODO replace with an actual verbose Logger Entry
-          error_log(
-            'passed Data Source ID for Strawberryfield_flavor_datasource had NULL elements in its path or a source file does no longer exists'
-          );
+          //@TODO should we untrack when this is the case?
+          $this->getLogger()
+            ->warning('Passed Data Source with ID  @id for Strawberryfield_flavor_datasource had NULL elements in its path or a source file does no longer exists',
+              [
+                '@id' => $item_id,
+              ]
+            );
         }
       }
     }
-
     return $documents;
   }
 
@@ -529,7 +630,6 @@ class StrawberryfieldFlavorDatasource extends DatasourcePluginBase implements St
   public function viewItem(ComplexDataInterface $item, $view_mode, $langcode = NULL) {
     return [];
   }
-
   /**
    * {@inheritdoc}
    */

--- a/src/StrawberryfieldUtilityService.php
+++ b/src/StrawberryfieldUtilityService.php
@@ -194,7 +194,6 @@ class StrawberryfieldUtilityService implements StrawberryfieldUtilityServiceInte
     // @WARNING Never call this function inside any field based hook
     // Chances are the hook will be called invoked inside ::getFieldDefinitions
     // All you will find yourself inside a SUPER ETERNAL LOOP. You are adviced.
-    $fieldefinitions = [];
     $all_bundled_fields = $this->entityFieldManager->getFieldDefinitions('node', $bundle);
     $all_sbf_fields = $this->getStrawberryfieldMachineNames();
     $all_sbf_fields = array_flip($all_sbf_fields);

--- a/src/TypedData/StrawberryfieldFlavorDataDefinition.php
+++ b/src/TypedData/StrawberryfieldFlavorDataDefinition.php
@@ -21,9 +21,11 @@ class StrawberryfieldFlavorDataDefinition extends ComplexDataDefinitionBase {
       $info = &$this->propertyDefinitions;
       $info['item_id'] = DataDefinition::create('string')->setLabel('Item ID');
       $info['sequence_id'] = DataDefinition::create('string')->setLabel('Sequence ID');
+      $info['sequence_total'] = DataDefinition::create('string')->setLabel('Expected total sequence count');
       $info['uri'] = DataDefinition::create('string')->setLabel('A source or related Uri/URL');
       $info['checksum'] = DataDefinition::create('string')->setLabel('Checksum that can be used to check if the source needs reprocessing');
       $info['processor_id'] = DataDefinition::create('string')->setLabel('Processor Plugin id that populated this data');
+      $info['config_processor_id'] = DataDefinition::create('string')->setLabel('Processor Config id that populated this data');
       $info['file_uuid'] = DataDefinition::create('string')->setLabel('Source File UUID (first one passed in a Post Processor chain)');
       $info['parent_id'] = DataReferenceTargetDefinition::create('integer')->setLabel('Parent Node ID');
       $info['target_id'] = DataReferenceDefinition::create('entity')
@@ -39,6 +41,7 @@ class StrawberryfieldFlavorDataDefinition extends ComplexDataDefinitionBase {
         ->setTargetDefinition(EntityDataDefinition::create('file'))
         ->addConstraint('EntityType', 'file');
       $info['fulltext'] = DataDefinition::create('string')->setLabel('Unmodified data body');
+      $info['plaintext'] = DataDefinition::create('string')->setLabel('Data body containing un formatted text from fulltext');
       //§/ required by Content Access processor , maybe we can disable it in some manner
       $info['status'] = DataDefinition::create('boolean')->setLabel('Status');
       $info['uid'] = DataDefinition::create('integer')->setLabel('UID');

--- a/strawberryfield.services.yml
+++ b/strawberryfield.services.yml
@@ -4,7 +4,7 @@ services:
     arguments: [ '@file_system', '@entity_type.manager', '@config.factory','@module_handler', '@entity_field.manager', '@plugin.manager.search_api.parse_mode']
   strawberryfield.file_persister:
     class: Drupal\strawberryfield\StrawberryfieldFilePersisterService
-    arguments: [ '@file_system', '@file.usage', '@entity_type.manager', '@stream_wrapper_manager', '@plugin.manager.archiver', '@config.factory','@current_user','@language_manager','@transliteration','@module_handler', '@logger.factory','@strawberryfield.utility']
+    arguments: [ '@file_system', '@file.usage', '@entity_type.manager', '@stream_wrapper_manager', '@plugin.manager.archiver', '@config.factory', '@current_user', '@language_manager', '@transliteration', '@module_handler', '@logger.factory', '@strawberryfield.utility']
     tags:
       - { name: backend_overridable }
   strawberryfield.keyname_manager:
@@ -24,41 +24,52 @@ services:
       class: Drupal\strawberryfield\EventSubscriber\StrawberryfieldEventPresaveSubscriberAsFileStructureGenerator
       tags:
         - {name: event_subscriber}
-      arguments: ['@string_translation', '@messenger','@logger.factory','@strawberryfield.file_persister','@current_user']
+      arguments: ['@string_translation', '@messenger', '@logger.factory', '@strawberryfield.file_persister', '@current_user']
   strawberryfield.presavefilepersister_subscriber:
     class: Drupal\strawberryfield\EventSubscriber\StrawberryfieldEventPresaveSubscriberFilePersister
     tags:
       - {name: event_subscriber}
-    arguments: ['@string_translation', '@messenger','@logger.factory','@strawberryfield.file_persister','@current_user']
+    arguments: ['@string_translation', '@messenger', '@logger.factory', '@strawberryfield.file_persister', '@current_user']
   strawberryfield.presavesetlabelfrommetadata_subscriber:
      class: Drupal\strawberryfield\EventSubscriber\StrawberryfieldEventPresaveSubscriberSetTitlefromMetadata
      tags:
        - {name: event_subscriber}
-     arguments: ['@string_translation', '@messenger','@logger.factory','@current_user']
+     arguments: ['@string_translation', '@messenger', '@logger.factory', '@current_user']
   strawberryfield.insertdeposit_subscriber:
     class: Drupal\strawberryfield\EventSubscriber\StrawberryfieldEventInsertSubscriberDepositDO
     tags:
       - {name: event_subscriber}
-    arguments: ['@string_translation', '@messenger', '@serializer','@config.factory','@logger.factory','@strawberryfield.file_persister','@current_user']
+    arguments: ['@string_translation', '@messenger', '@serializer', '@config.factory', '@logger.factory', '@strawberryfield.file_persister', '@current_user']
   strawberryfield.insertfileusage_subscriber:
     class: Drupal\strawberryfield\EventSubscriber\StrawberryfieldEventInsertFileUsageUpdater
     tags:
       - {name: event_subscriber}
-    arguments: ['@string_translation', '@messenger','@logger.factory','@strawberryfield.file_persister','@current_user']
+    arguments: ['@string_translation', '@messenger', '@logger.factory', '@strawberryfield.file_persister', '@current_user']
   strawberryfield.deletefileusage_subscriber:
     class: Drupal\strawberryfield\EventSubscriber\StrawberryfieldEventDeleteFileUsageDeleter
     tags:
       - {name: event_subscriber}
-    arguments: ['@string_translation', '@messenger','@logger.factory','@strawberryfield.file_persister','@current_user']
+    arguments: ['@string_translation', '@messenger', '@logger.factory', '@strawberryfield.file_persister', '@current_user']
   strawberryfield.file_delete_flavor:
     class: Drupal\strawberryfield\EventSubscriber\StrawberryEventSaveFileDeleteFlavorSubscriber
     tags:
       - { name: event_subscriber }
+    arguments: ['@keyvalue']
+  strawberryfield.node_delete_flavor:
+    class: Drupal\strawberryfield\EventSubscriber\StrawberryEventDeleteFlavorSubscriber
+    tags:
+      - { name: event_subscriber }
+    arguments: ['@keyvalue']
+  strawberryfield.search_api_relations_alter:
+    class: Drupal\strawberryfield\EventSubscriber\StrawberryfieldEventSearchApiForeignRelationshipsMapping
+    tags:
+      - { name: event_subscriber }
+    arguments: ['@strawberryfield.utility']
   strawberryfield.paramconverter.entity:
     class: Drupal\strawberryfield\ParamConverter\UuidEntityConverter
     tags:
       - { name: paramconverter , priority: 10 }
-    arguments: ['@entity_type.manager','@entity.repository']
+    arguments: ['@entity_type.manager', '@entity.repository']
   strawberryfield.mime_type.guesser.mime:
     class: Drupal\strawberryfield\StrawberryfieldMimeService
     arguments: [ '@module_handler' ]


### PR DESCRIPTION
…vor Solr Documents (#168)

* First pass on adding `plaintext` and total sequence capabilities to SB Flavor Solr docs

Needs more work on the new config options for the data source. Lot's of stuff missing there still

* Solr Flavor Document Untracking fixes

@pcambra i found a few issues when testing other parts of the code with this that i had not seen in the first simple test (my bad) when i merged your code a few days ago:

- Without a range or limit, the default limit was always 10. So we got only 10 Solr Flavor Documents deleted instead of everything. I added some logic to fetch in 200 increments and iterate until all was fetched and then untrack all. Please give this a sanity check, suggest changes to make the code cleaner. I tested locally but would appreciate you can validate the code (or suggest changes)

- If Solr Documents where found and returned, because of Highlighting (HL argument) at Solr Level, and because all fulltext fields are being requested (thus everything gets the standard Solr highlight) we got a searchAPI exception and a 500 on screen. Not sure why this not failed, maybe during my tests no Solr Documents where even found? I do not know. But if you test locally you will see that error popup.

Solution i found was as in other pure Flavor Solr Queries, add the forced $query->setOption('ocr_highlight', 'on'); for this case and let the Server deal with it.
Just for sanity( because an exception while saving an ADO is a deal breaker) i added a catch (not a cat) with a watchdog (not a dog) exception

Please test this @giancarlobi too.

Since the limit is a bit high (200 documents) and you may not want to HOCR a document with 300 pages to test this i would recommend changing the $limit value to 5 or less, and see if this does what it should

FYI: this is the Solr error i got:

```
webapp=/solr path=/select params={json.nl=flat&hl=true&TZ=America/New_York&fl=*,score&hl.requireFieldMatch=false&start=0&hl.fragsize=0&fq=ss_file_uuid:"db487100-b45b-49f3-b095-cc20a7aff38b"&fq=ss_search_api_datasource:"strawberryfield_flavor_datasource"&fq=ss_uuid:"71946522-ee87-405c-b175-9bd23a4a0f53"&fq=%2Bindex_id:default_solr_index+%2Bhash:5qc1nk&fq=ss_search_api_language:("en"+"und")&rows=200&hl.simple.pre=[HIGHLIGHT]&hl.snippets=3&q=*:*&hl.mergeContiguous=false&hl.simple.post=[/HIGHLIGHT]&omitHeader=true&hl.fl=*&wt=json} hits=35 status=500 QTime=19
2021-03-25 21:28:03.981 ERROR (qtp722951168-16) [   x:drupal] o.a.s.s.HttpSolrCall null:org.apache.solr.common.SolrException: org.apache.lucene.search.highlight.InvalidTokenOffsetsException: Token  exceeds length of provided text sized 723
```

* Update Config form for Metadata Display Selection.

Not used yet, but moving forward, means no errors and config seems to be saved correctly, and loaded back. @pcambra could you check if i go the schema correct? I'm really bad a schemas

* Keeps track of processed class

Normalization for debugging.

* Inspired on Pedro's work. Deletes al Flavors for a gone ADO

drush cr to make sure new service gets loaded.

* Remove also from Key Value when Removed from Index/tracker

@giancarlobi this now also removes it from the Key value when unindexed. Hope  this helps with the issue of re-appearing/race-condition ghosts. But we can still do better if so. I personally feel we can also have a Manual clean up option in case this happens as final option.

A side note:

The way the Tracker/Indexing works is a bit erratic when reindexing. Lets say you mark all for reindex. and some SBF are missing, if for a set of (50) non exist, the batch will stop. If you keep reindexing it will continue. Just in case you wonder why for that case you end with a 80%. Pressing index after that will keep doing it and all the ones not found will be untracked already.

* Implemetent StrawberryfieldEventSearchApiForeignRelationshipsMapping

@giancarlobi this fixes the issue with the failing EntityQuery by removing every entity reference property belonging to a SBF. That means no more Error messages.
Still, this does not solved the fact that once an ADO is removed or updated, any other ADO pointing to it is not updated.
For that i will make another different Event Subscriber that will use the Index itself to query for any Solr Field that has a SBF property path pointing to a dynamic entity reference and check if "nid" is present. That way we can make it faster than an entityQuery ever could. Only issue is we have to Document/enforce that people always index their "nid" too. But that is way easier.